### PR TITLE
Finished  Menu Item index page, test, and .stories file

### DIFF
--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.js
@@ -1,15 +1,45 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemTable from 'main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable';
+import { useCurrentUser , hasRole} from 'main/utils/currentUser'
+import { Button } from 'react-bootstrap';
 
 export default function UCSBDiningCommonsMenuItemIndexPage() {
 
-  // Stryker disable all : placeholder for future implementation
-  return (
-    <BasicLayout>
-      <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p><a href="/ucsbdiningcommonsmenuitem/create">Create</a></p>
-        <p><a href="/ucsbdiningcommonsmenuitem/edit/1">Edit</a></p>
-      </div>
-    </BasicLayout>
-  )
+    const currentUser = useCurrentUser();
+
+    const { data: menuItems, error: _error, status: _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            ["/api/ucsbdiningcommonsmenuitem/all"],
+            { method: "GET", url: "/api/ucsbdiningcommonsmenuitem/all" },
+            // Stryker disable next-line all : don't test default value of empty list
+            []
+        );
+
+    const createButton = () => {
+        if (hasRole(currentUser, "ROLE_ADMIN")) {
+            return (
+                <Button
+                    variant="primary"
+                    href="/ucsbdiningcommonsmenuitem/create"
+                    style={{ float: "right" }}
+                >
+                    Create Menu Item
+                </Button>
+            )
+        } 
+    }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                {createButton()}
+                <h1>UCSB Dining Commons Menu Items</h1>
+                <UCSBDiningCommonsMenuItemTable menuItems={menuItems} currentUser={currentUser} />
+            </div>
+        </BasicLayout>
+    );
 }

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.stories.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+import { rest } from "msw";
+
+import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
+
+export default {
+    title: 'pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage',
+    component: UCSBDiningCommonsMenuItemIndexPage
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemIndexPage storybook={true}/>;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/ucsbdiningcommonsmenuitem/all', (_req, res, ctx) => {
+            return res(ctx.json([]));
+        }),
+    ]
+}
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/ucsbdiningcommonsmenuitem/all', (_req, res, ctx) => {
+            return res(ctx.json(ucsbDiningCommonsMenuItemFixtures.threeMenuItems));
+        }),
+    ],
+}
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.adminUser));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/ucsbdiningcommonsmenuitem/all', (_req, res, ctx) => {
+            return res(ctx.json(ucsbDiningCommonsMenuItemFixtures.threeMenuItems));
+        }),
+        rest.delete('/api/ucsbdiningcommonsmenuitem', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
@@ -1,17 +1,30 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
 describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "UCSBDiningCommonsMenuItemTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();
@@ -20,13 +33,19 @@ describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
     const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
 
-        setupUserOnly();
+    test("Renders with Create Button for admin user", async () => {
+        setupAdminUser();
+        axiosMock.onGet("/api/ucsbdiningcommonsmenuitem/all").reply(200, []);
 
-        // act
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -35,10 +54,103 @@ describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
-        expect(screen.getByText("Create")).toBeInTheDocument();
-        expect(screen.getByText("Edit")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText(/Create Menu Item/)).toBeInTheDocument();
+        });
+        const button = screen.getByText(/Create Menu Item/);
+        expect(button).toHaveAttribute("href", "/ucsbdiningcommonsmenuitem/create");
+        expect(button).toHaveAttribute("style", "float: right;");
+    });
+
+    test("renders three menu items correctly for regular user", async () => {
+        setupUserOnly();
+        axiosMock.onGet("/api/ucsbdiningcommonsmenuitem/all").reply(200, ucsbDiningCommonsMenuItemFixtures.threeMenuItems);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+        const createMenuItemButton = screen.queryByText("Create Menu Item");
+        expect(createMenuItemButton).not.toBeInTheDocument();
+
+        const name1 = screen.getByText("Baked Pesto Pasta with Chicken");
+        expect(name1).toBeInTheDocument();
+
+        const name2 = screen.getByText("Tofu Banh Mi Sandwich (v)");
+        expect(name2).toBeInTheDocument();
+
+        const name3 = screen.getByText("Chicken Caesar Salad");
+        expect(name3).toBeInTheDocument();
+
+
+        // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
+        expect(screen.queryByTestId("RestaurantTable-cell-row-0-col-Delete-button")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("RestaurantTable-cell-row-0-col-Edit-button")).not.toBeInTheDocument();
+    });
+
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        axiosMock.onGet("/api/ucsbdiningcommonsmenuitem/all").timeout();
+
+        const restoreConsole = mockConsole();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+        
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/ucsbdiningcommonsmenuitem/all");
+        restoreConsole();
+
+    });
+
+    test("what happens when you click delete, admin", async () => {
+        setupAdminUser();
+
+        axiosMock.onGet("/api/ucsbdiningcommonsmenuitem/all").reply(200, ucsbDiningCommonsMenuItemFixtures.threeMenuItems);
+        axiosMock.onDelete("/api/ucsbdiningcommonsmenuitem").reply(200, "Menu Item with id 1 was deleted");
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Menu Item with id 1 was deleted") });
+
+        await waitFor(() => { expect(axiosMock.history.delete.length).toBe(1); });
+        expect(axiosMock.history.delete[0].url).toBe("/api/ucsbdiningcommonsmenuitem");
+        expect(axiosMock.history.delete[0].url).toBe("/api/ucsbdiningcommonsmenuitem");
+        expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
     });
 
 });


### PR DESCRIPTION
In this PR I finished the Dining Commons Menu Item Index Page, tests and .stories file.
In order to test this deploy on local host, navigate to UCSBDiningCommonsMenuItem in the navbar. Alternatively, follow the storybook link to this PR and check the UCSBDiningCommonsMenuItemEditPage.
Attached are the screenshots to the frontend changes, Empty, three items with ordinary user, and three items with admin user.

storybook link: https://ucsb-cs156-m23.github.io/team03-m23-9am-1/

<img width="1345" alt="Screenshot 2023-08-11 at 10 10 13 PM" src="https://github.com/ucsb-cs156-m23/team03-m23-9am-1/assets/108090479/07a13b59-c3f0-4ee4-809d-2badcda7efff">

<img width="1345" alt="Screenshot 2023-08-11 at 10 10 34 PM" src="https://github.com/ucsb-cs156-m23/team03-m23-9am-1/assets/108090479/19c27fa2-0f55-4d85-a4fe-59aca3eb5f5f">

<img width="1342" alt="Screenshot 2023-08-11 at 10 10 45 PM" src="https://github.com/ucsb-cs156-m23/team03-m23-9am-1/assets/108090479/264cacbf-2406-4a11-b916-d60100abd19e">


Closes #13 