### PR TITLE
create page implemented

### DIFF
--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
@@ -1,13 +1,51 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function MenuItemReviewCreatePage() {
+export default function RestaurantCreatePage({storybook=false}) {
 
-  // Stryker disable all : placeholder for future implementation
+  const objectToAxiosParams = (reviews) => ({
+    url: "/api/menuitemreview/post",
+    method: "POST",
+    params: {
+     itemId: reviews.itemId,
+     reviewerEmail: reviews.reviewerEmail,
+     stars: reviews.stars,
+     dateReviewed: reviews.dateReviewed,
+     comments: reviews.comments
+    }
+  });
+
+  const onSuccess = (reviews) => {
+    toast(`New review Created - itemId: ${reviews.itemId} reviewerEmail: ${reviews.reviewerEmail} stars: ${reviews.stars} dateReviewed: ${reviews.dateReviewed} comments: ${reviews.comments}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/meuitemreview/all"] // mutation makes this key stale so that pages relying on it reload
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreview" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Review</h1>
+        <MenuItemReviewForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   )
 }
+

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage"
+
+export default {
+    title: 'pages/MenuItemReview/MenuItemReviewCreatePage',
+    component: MenuItemReviewCreatePage
+};
+
+const Template = () => <MenuItemReviewCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/menuitemreview/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
@@ -1,31 +1,48 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-describe("PlaceholderCreatePage tests", () => {
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("MenuItemReviewCreatePage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
 
-    const setupUserOnly = () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+    });
 
     const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
-
-        setupUserOnly();
-       
-        // act
+    test("renders without crashing", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -33,11 +50,75 @@ describe("PlaceholderCreatePage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
-
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
     });
 
+    test("on submit, makes request to backend, and redirects to /menuitemreview", async () => {
+
+        const queryClient = new QueryClient();
+        const review = {
+            itemId: "3",
+            reviewerEmail: "pds@ucsb.edu",
+            stars: "5",
+            dateReviewed: "2022-01-02T12:00:00",
+            comments: "test comment"
+        };
+
+        axiosMock.onPost("/api/menuitemreview/post").reply(202, review);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByLabelText("Item Id")).toBeInTheDocument();
+        });
+
+        const idInput = screen.getByLabelText("Item Id");
+        expect(idInput).toBeInTheDocument();
+
+        const emailInput = screen.getByLabelText("Reviewer Email");
+        expect(emailInput).toBeInTheDocument();
+
+        const starsInput = screen.getByLabelText("Stars");
+        expect(starsInput).toBeInTheDocument();
+
+        const dateInput = screen.getByLabelText("Date Reviewed");
+        expect(dateInput).toBeInTheDocument();
+
+        const commentsInput = screen.getByLabelText("Comments");
+        expect(commentsInput).toBeInTheDocument();
+
+
+
+        const createButton = screen.getByText("Create");
+        expect(createButton).toBeInTheDocument();
+
+        fireEvent.change(idInput, { target: { value: '3' } })
+        fireEvent.change(emailInput, { target: { value: 'pds@ucsb.edu' } })
+        fireEvent.change(starsInput, { target: { value: '5' } })
+        fireEvent.change(dateInput, { target: { value: '2022-01-02T12:00:00' } })
+        fireEvent.change(commentsInput, { target: { value: 'test comment' } })
+        
+
+        fireEvent.click(createButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual({
+            itemId: "3",
+            reviewerEmail: "pds@ucsb.edu",
+            stars: "5",
+            dateReviewed: "2022-01-02T12:00:00",
+            comments: "test comment"
+        });
+
+        // assert - check that the toast was called with the expected message
+        expect(mockToast).toBeCalledWith("New review Created - itemId: 3 reviewerEmail: pds@ucsb.edu stars: 5 dateReviewed: 2022-01-02T12:00:00 comments: test comment");
+        expect(mockNavigate).toBeCalledWith({ "to": "/menuitemreview" });
+
+    });
 });
-
-


### PR DESCRIPTION
In this PR I implemented the create Page for menu item reviews.  I also finished the respective test file and added the .stories file as well. In order to test my create page you enter appropriate inputs into the fields and hit create. This then should prompt a message saying that the review has been created and then redirect you to the index page.  Then navigate to swagger and scroll down to /api/menuitemreview/all and hit execute, your review should be there. 

Link to Published StoryBook: https://ucsb-cs156-m23.github.io/team03-m23-9am-1/


![image](https://github.com/ucsb-cs156-m23/team03-m23-9am-1/assets/97569267/bf188228-735c-42bc-a4df-ed24ea4e0957)
